### PR TITLE
Install `devDependencies` again after git clean

### DIFF
--- a/commands/branch.js
+++ b/commands/branch.js
@@ -10,6 +10,7 @@ export async function command() {
 	await exec('obt', 'verify');
 	await exec('obt', 'test');
 	await exec('git', 'clean', '-fxd');
+	await exec('npm', 'install', '--only=dev');
 	await exec('occ', '--name', env.name, '0.0.0');
 	await exec('obt', 'install', '--ignore-bower');
 	await exec('obt', 'test', '--ignore-bower');


### PR DESCRIPTION
this is maybe not an elegant solution, maybe in the future builds can work differently so the `git clean` isn't required. (like building to a `build/` folder)