### PR TITLE
Restore `execa` over `./exec` for the bundle size library.

### DIFF
--- a/lib/bundle-size-pr-comment.js
+++ b/lib/bundle-size-pr-comment.js
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch';
-import exec from './exec';
+import execa from 'execa';
 import env from './env';
 
 export default async () => {
@@ -7,7 +7,7 @@ export default async () => {
     // Don't fail ci because we couldn't get bundle information, just return.
     let bundleSizeMessage;
     try {
-        const { stdout } = await exec('origami-bundle-size');
+        const { stdout } = await execa('origami-bundle-size');
         bundleSizeMessage = stdout;
     } catch (error) {
         console.log(error.message);

--- a/lib/bundle-size-pr-comment.js
+++ b/lib/bundle-size-pr-comment.js
@@ -3,58 +3,58 @@ import execa from 'execa';
 import env from './env';
 
 export default async () => {
-    // Get bundle size message.
-    // Don't fail ci because we couldn't get bundle information, just return.
-    let bundleSizeMessage;
-    try {
-        const { stdout } = await execa('origami-bundle-size');
-        bundleSizeMessage = stdout;
-    } catch (error) {
-        console.log(error.message);
-        return;
-    }
+	// Get bundle size message.
+	// Don't fail ci because we couldn't get bundle information, just return.
+	let bundleSizeMessage;
+	try {
+		const {stdout} = await execa('origami-bundle-size');
+		bundleSizeMessage = stdout;
+	} catch (error) {
+		console.log(error.message);
+		return;
+	}
 
-    // Log the bundle size message.
-    console.log(bundleSizeMessage);
+	// Log the bundle size message.
+	console.log(bundleSizeMessage);
 
-    // Find the PR number to post the bundle size message to.
-    // Don't fail ci if no PR number is found, just return.
-    if (!env.pullRequestUrl) {
-        console.log('No pull request url to post bundle information to.');
-        return;
-    }
+	// Find the PR number to post the bundle size message to.
+	// Don't fail ci if no PR number is found, just return.
+	if (!env.pullRequestUrl) {
+		console.log('No pull request url to post bundle information to.');
+		return;
+	}
 
-    const prNumber = env.pullRequestUrl.match(/([0-9]+)$/)[0];
-    if(!prNumber) {
-        console.log('No pull request number to post bundle information to.');
-        return;
-    }
+	const prNumber = env.pullRequestUrl.match(/([0-9]+)$/)[0];
+	if (!prNumber) {
+		console.log('No pull request number to post bundle information to.');
+		return;
+	}
 
-    // Post bundle size message to the Github PR.
-    // Don't fail ci because we couldn't post bundle information.
-    try {
-        const host = `api.github.com`;
-        const path = `repos/Financial-Times/${env.name}/issues/${prNumber}/comments`;
-        const githubEndpoint = `https://${host}/${path}`;
-        const response = await fetch(githubEndpoint, {
-            method: 'POST',
-            body: JSON.stringify({ body: bundleSizeMessage }),
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `token ${ env.githubToken }`
-            }
-        });
+	// Post bundle size message to the Github PR.
+	// Don't fail ci because we couldn't post bundle information.
+	try {
+		const host = `api.github.com`;
+		const path = `repos/Financial-Times/${env.name}/issues/${prNumber}/comments`;
+		const githubEndpoint = `https://${host}/${path}`;
+		const response = await fetch(githubEndpoint, {
+			method: 'POST',
+			body: JSON.stringify({body: bundleSizeMessage}),
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `token ${env.githubToken}`,
+			},
+		});
 
-        if (!response.ok) {
-            console.log(
-                `Could not post a bundle size comment to "${githubEndpoint}".` +
-                `Status: ${response.status}.`
-            );
-        }
-    } catch (error) {
-        console.log(
-            `There was an error posting bundle information to "${githubEndpoint}".`,
-            error
-        );
-    }
+		if (!response.ok) {
+			console.log(
+				`Could not post a bundle size comment to "${githubEndpoint}".` +
+					`Status: ${response.status}.`
+			);
+		}
+	} catch (error) {
+		console.log(
+			`There was an error posting bundle information to "${githubEndpoint}".`,
+			error
+		);
+	}
 };

--- a/lib/bundle-size-pr-comment.js
+++ b/lib/bundle-size-pr-comment.js
@@ -1,13 +1,16 @@
 import fetch from 'node-fetch';
 import execa from 'execa';
 import env from './env';
+import {getExecEnv} from './exec.js';
 
 export default async () => {
 	// Get bundle size message.
 	// Don't fail ci because we couldn't get bundle information, just return.
 	let bundleSizeMessage;
 	try {
-		const {stdout} = await execa('origami-bundle-size');
+		const {stdout} = await execa('origami-bundle-size', {
+			env: getExecEnv(),
+		});
 		bundleSizeMessage = stdout;
 	} catch (error) {
 		console.log(error.message);

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,8 +3,8 @@ import env from './env';
 
 export function getExecEnv() {
 	return {
-		PATH: `${env.npmInstallPrefix}/bin:${env.path}`
-	}
+		PATH: `${env.npmInstallPrefix}/bin:${env.path}`,
+	};
 }
 
 export default async function exec(program, ...args) {
@@ -13,6 +13,6 @@ export default async function exec(program, ...args) {
 		buffer: false,
 		stdout: 'inherit',
 		stderr: 'inherit',
-		env: getExecEnv()
+		env: getExecEnv(),
 	});
 }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,14 +1,18 @@
 import execa from 'execa';
 import env from './env';
 
+export function getExecEnv() {
+	return {
+		PATH: `${env.npmInstallPrefix}/bin:${env.path}`
+	}
+}
+
 export default async function exec(program, ...args) {
 	return execa(program, args, {
 		preferLocal: true,
 		buffer: false,
 		stdout: 'inherit',
 		stderr: 'inherit',
-		env: {
-			PATH: `${env.npmInstallPrefix}/bin:${env.path}`
-		}
+		env: getExecEnv()
 	});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "origami-ci-tools",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "origami-ci-tools",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Commands to help with Continuous Integration of Origami components",
 	"main": "index.js",
 	"module": "main.js",


### PR DESCRIPTION
Bundle sizes aren't being posted to PRs at the moment. `./exec`
sets `buffer: false` which breaks the current Promise based
implementation.