### PR TITLE
throw an error if the NPM_TOKEN has not been set and the release command has been called.

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -12,6 +12,12 @@ export let globalDependencies = ['occ'];
 export async function command() {
 	await exec('occ', '--name', env.name, env.version);
 	let npmrcPath = resolvePath(homedir(), '.npmrc');
+	if (env.npmToken == undefined) {
+		throw new Error(
+			'To use the release command you need to set the environment variable "NPM_TOKEN" with a valid npm token. \
+			You can contact Origami for help with this via origami.support@ft.com or the Slack channel #ft-origami.'
+		);
+	}
 	await fs.writeFile(
 		npmrcPath,
 		`//registry.npmjs.org/:_authToken=${env.npmToken}`


### PR DESCRIPTION
Customer Products have started to use origami-ci for n-components but they got stuck because they were using the environment variable NPM_AUTH_TOKEN and not NPM_TOKEN