### PR TITLE
Set up CircleCI for testing/linting and automated publishing to npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - run: npm cit
+  publish_to_npm:
+    docker:
+      - image: circleci/node:12
+    steps:
+      - checkout
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+      - run: npm publish
+  
+workflows:
+  test:
+    jobs:
+      - test
+      - publish_to_npm:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,7 +1,4 @@
-import * as branch from "./branch.js"
-import * as release from "./release.js"
+import * as branch from './branch.js';
+import * as release from './release.js';
 
-export {
-	branch,
-	release
-}
+export {branch, release};

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,6 +131,12 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
+    },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
 	"bin": {
 		"origami-ci": "./index.js"
 	},
-	"scripts": {},
+	"scripts": {
+		"test": "prettier --check '*.js' '{commands,lib}/**/*.js'",
+		"format": "prettier --write '*.js' '{commands,lib}/**/*.js'"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/Financial-Times/origami-ci-tools.git"
@@ -23,7 +26,9 @@
 		"url": "https://github.com/Financial-Times/origami-ci-tools/issues"
 	},
 	"homepage": "https://github.com/Financial-Times/origami-ci-tools#readme",
-	"devDependencies": {},
+	"devDependencies": {
+		"prettier": "^1.19.1"
+	},
 	"dependencies": {
 		"esm": "^3.2.25",
 		"execa": "^2.0.4",


### PR DESCRIPTION
- I saw the project has a Prettier config so I decided to add prettier as a development dependency and add scripts to check project conforms to prettier config and another command to make project conform to prettier config.

- Added CircleCI config for testing and automated publishing to npm - similar in nature to the workflow for Origami components and libraries such as polyfill-library -- pushing a semver compatible Git Tag to GitHub will trigger a publish to npm with the corresponding Git Tag as the package's version.