### PR TITLE
Only add the latest npm dist-tag if the version being published is the largest stable version out of all the previously published versions

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -1,6 +1,7 @@
 import {promises as fs} from 'fs';
 import {homedir} from 'os';
 import {resolve as resolvePath} from 'path';
+import {gt, coerce} from 'semver';
 
 import exec from '../lib/exec';
 import env from '../lib/env';
@@ -10,7 +11,6 @@ export let description = 'run release commands';
 export let globalDependencies = ['occ'];
 
 export async function command() {
-	await exec('occ', '--name', env.name, env.version);
 	let npmrcPath = resolvePath(homedir(), '.npmrc');
 	if (env.npmToken == undefined) {
 		throw new Error(
@@ -22,5 +22,38 @@ export async function command() {
 		npmrcPath,
 		`//registry.npmjs.org/:_authToken=${env.npmToken}`
 	);
-	await exec('npm', 'publish', '--access', 'public');
+
+	/*
+		Publishing to npm without `--tag` being set will make that version have the dist-tag `latest`.
+		When someone does an install of the package without declaring a version or dist-tag then the 
+		`latest` dist-tag is used. This is a problem if an Origami component has a fixed/feature backported
+		to an old version and that old version is published, because it will then be tagged as the `latest`
+		version, which means users would not get the version they expect when they run `npm install o-component`.
+
+		The code below attempts to solve the above issue by checking that the version being published is not
+		 a prerelease and is the largest version compared to all previously published version. If the version
+		 being published is either a prerelease or not the largest version then we tag the release with the 
+		 version to ensure that it does not get tagged with `latest`.
+	*/
+	const newVersion = coerce(env.version);
+	const newVersionIsNotPrerelease = newVersion.prerelease.length === 0;
+
+	const versions = await exec('npm', 'info', env.name, 'versions', '--json');
+
+	const stableVersions = versions.filter(version => {
+		const v = coerce(version);
+		return v.prerelease.length === 0;
+	});
+
+	const newVersionIsLargestVersion = stableVersions.every(version => {
+		return gt(newVersion, version);
+	});
+
+	await exec('occ', '--name', env.name, env.version);
+
+	if (newVersionIsNotPrerelease && newVersionIsLargestVersion) {
+		await exec('npm', 'publish', '--access', 'public');
+	} else {
+		await exec('npm', 'publish', '--access', 'public', '--tag', env.version);
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,13 @@
             "semver": "^5.5.0",
             "shebang-command": "^1.2.0",
             "which": "^1.2.9"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+              "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            }
           }
         },
         "get-stream": {
@@ -147,9 +154,9 @@
       }
     },
     "semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"esm": "^3.2.25",
 		"execa": "^2.0.4",
 		"minimist": "^1.2.0",
-		"node-fetch": "^2.6.0"
+		"node-fetch": "^2.6.0",
+		"semver": "^6.3.0"
 	},
 	"_origamiGlobalDependencies": {
 		"@financial-times/origami-bundle-size-cli": "^1.0.0",


### PR DESCRIPTION
Publishing any version to npm will make that version have the dist-tag `latest`. When someone does an install of the package without declaring a version or dist-tag then the `latest` dist-tag is used. This is a problem if an Origami component has a fixed/feature backported to an old version and that old version is published, because it will then be tagged as the `latest` version, which means users would not get the version they expect when they run `npm install o-component`.

This pull-request attempts to solve the above issue by checking that the version being published is not a prerelease and is the largest version compared to all previously published version. If the version being published is either a prerelease or not the largest version then we tag the release with the version to ensure that it does not get tagged with `latest`.

Solves https://github.com/Financial-Times/origami-ci-tools/issues/10