### PR TITLE
Parse version data on release.

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -40,7 +40,9 @@ export async function command() {
 
 	await exec('occ', '--name', env.name, '0.0.0');
 
-	const versions = JSON.parse(await exec('npm', 'info', '.', 'versions', '--json'));
+	const versions = JSON.parse(
+		await exec('npm', 'info', '.', 'versions', '--json')
+	);
 
 	const stableVersions = versions.filter(version => {
 		const v = coerce(version);

--- a/commands/release.js
+++ b/commands/release.js
@@ -25,14 +25,14 @@ export async function command() {
 
 	/*
 		Publishing to npm without `--tag` being set will make that version have the dist-tag `latest`.
-		When someone does an install of the package without declaring a version or dist-tag then the 
+		When someone does an install of the package without declaring a version or dist-tag then the
 		`latest` dist-tag is used. This is a problem if an Origami component has a fixed/feature backported
 		to an old version and that old version is published, because it will then be tagged as the `latest`
 		version, which means users would not get the version they expect when they run `npm install o-component`.
 
 		The code below attempts to solve the above issue by checking that the version being published is not
 		 a prerelease and is the largest version compared to all previously published version. If the version
-		 being published is either a prerelease or not the largest version then we tag the release with the 
+		 being published is either a prerelease or not the largest version then we tag the release with the
 		 version to ensure that it does not get tagged with `latest`.
 	*/
 	const newVersion = coerce(env.version);
@@ -40,7 +40,7 @@ export async function command() {
 
 	await exec('occ', '--name', env.name, '0.0.0');
 
-	const versions = await exec('npm', 'info', '.', 'versions', '--json');
+	const versions = JSON.parse(await exec('npm', 'info', '.', 'versions', '--json'));
 
 	const stableVersions = versions.filter(version => {
 		const v = coerce(version);


### PR DESCRIPTION
See failed build: https://circleci.com/gh/Financial-Times/o-fonts/133