### PR TITLE
Install Origami global dependencies at the specified version.

### DIFF
--- a/lib/install-dependencies.js
+++ b/lib/install-dependencies.js
@@ -37,7 +37,7 @@ export default async function installDependencies(names) {
 		return `${name}@${version}`;
 	});
 
-	let installs = names.map(spec => {
+	let installs = specs.map(spec => {
 		return exec('npm', 'install', '-g', spec, '--prefix', env.npmInstallPrefix);
 	});
 


### PR DESCRIPTION
origami-ci-tools is currently installing global dependencies at
the latest version. This was noticed because obt v9 has an issue
that in CI is preventing it from running bower install.

This means origami-component-converter v1 will have been used to
release bundle npm packages without commonjs. We may have gotten
away with it as all our recent majors of components use only esm
module syntax but could have been a problem if we released a patch
to a previous major version of a component which uses commonjs.
https://github.com/Financial-Times/origami-component-converter/issues/31