### PR TITLE
Upgrade origami-build-tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
 	"_origamiGlobalDependencies": {
 		"@financial-times/origami-bundle-size-cli": "^1.0.0",
 		"occ": "^0.15.0",
-		"origami-build-tools": "^8.2.5"
+		"origami-build-tools": "^9.0.4"
 	}
 }


### PR DESCRIPTION
The new version of obt uses our dart-sass library for faster builds.