### PR TITLE
Upgrade to origami-build-tools v10.

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,5 @@
+# Migration Guides
+
+## Migrating from v1 to v2
+
+Origami Build Tools v10 is now used as part of continuous integration. Migrate the component to be compatible with Origami Build Tools v10 ([origami-build-tools v10 migration guide](https://registry.origami.ft.com/components/origami-build-tools@10.0.1/readme?brand=master#migration-guides)).

--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ jobs:
 | `CIRCLE_PULL_REQUEST` | CircleCI-specific alternative to `ORIGAMI_PULL_REQUEST`. Set automatically by CircleCI | `https://github.com/Financial-Times/o-test-component/pull/1` |
 | `NPM_TOKEN` OR `NPM_AUTH_TOKEN` | The auth token used to publish npm packages | ` 09448d16328f2c7...`|
 | `GITHUB_TOKEN` | The auth token used to comment on Github pull requests | `r0wANL3eJ4keacHee1234o==`|
+
+## Migration Guides
+
+State | Major Version | Last Minor Release | Migration guide |
+:---: | :---: | :---: | :---:
+✨ active | 2 | N/A | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
+⚠ maintained | 1 | 1.3 | N/A |

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
 	"_origamiGlobalDependencies": {
 		"@financial-times/origami-bundle-size-cli": "^1.0.0",
 		"occ": "^0.15.0",
-		"origami-build-tools": "^9.0.5"
+		"origami-build-tools": "^10.0.0"
 	}
 }


### PR DESCRIPTION
Components may require modification for origami-build-tools v10,
therefore this must be a major release