### PR TITLE
add extension to relative imports to make the code work directly in a browser

### DIFF
--- a/commands/branch.js
+++ b/commands/branch.js
@@ -1,6 +1,6 @@
-import exec from '../lib/exec';
-import env from '../lib/env';
-import bundleSize from '../lib/bundle-size-pr-comment.js';
+import exec from '../lib/exec.js';
+import env from '../lib/env.js';
+import bundleSize from '../lib/bundle-size-pr-comment.js.js';
 import {promises as fs, existsSync} from 'fs';
 import tar from 'tar';
 import {promisify} from 'util';

--- a/commands/index.js
+++ b/commands/index.js
@@ -1,4 +1,4 @@
-import * as branch from './branch.js';
-import * as release from './release.js';
+import * as branch from './branch.js.js';
+import * as release from './release.js.js';
 
 export {branch, release};

--- a/commands/release.js
+++ b/commands/release.js
@@ -3,9 +3,9 @@ import {homedir} from 'os';
 import {resolve as resolvePath} from 'path';
 import {gt, coerce} from 'semver';
 
-import exec from '../lib/exec';
-import {execStdout} from '../lib/exec';
-import env from '../lib/env';
+import exec from '../lib/exec.js';
+import {execStdout} from '../lib/exec.js';
+import env from '../lib/env.js';
 
 export let description = 'run release commands';
 

--- a/lib/bundle-size-pr-comment.js
+++ b/lib/bundle-size-pr-comment.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import execa from 'execa';
-import env from './env';
-import {getExecEnv} from './exec.js';
+import env from './env.js';
+import {getExecEnv} from './exec.js.js';
 
 export default async () => {
 	// Get bundle size message.

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,5 +1,5 @@
 import execa from 'execa';
-import env from './env';
+import env from './env.js';
 
 export function getExecEnv() {
 	return {

--- a/lib/install-dependencies.js
+++ b/lib/install-dependencies.js
@@ -1,5 +1,5 @@
-import exec from './exec';
-import env from './env';
+import exec from './exec.js';
+import env from './env.js';
 import {resolve as resolvePath} from 'path';
 import {promises as fs} from 'fs';
 

--- a/main.js
+++ b/main.js
@@ -4,8 +4,8 @@ process.on('unhandledRejection', error => {
 });
 
 import parseArgv from 'minimist';
-import * as commands from './commands';
-import installDependencies from './lib/install-dependencies';
+import * as commands from './commands.js';
+import installDependencies from './lib/install-dependencies.js';
 
 let commandNames = Object.keys(commands);
 


### PR DESCRIPTION
relative imports require the full path including the extension because browsers use the import name to make a network request and they do not implicitly add a .js file extension if one is missing