### PR TITLE
Stop building the pa11y demo separately as obt test builds the pa11y demo now

### DIFF
--- a/commands/branch.js
+++ b/commands/branch.js
@@ -30,7 +30,6 @@ export async function command() {
 	}
 	let buildDir = 'occ-build-' + getShortId();
 	await exec('obt', 'install');
-	await exec('obt', 'demo', '--demo-filter', 'pa11y', '--suppress-errors');
 	await exec('obt', 'verify');
 	await exec('obt', 'test');
 	await exec('git', 'clean', '-fxd');

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
 	"_origamiGlobalDependencies": {
 		"@financial-times/origami-bundle-size-cli": "^1.0.0",
 		"occ": "^0.16.2",
-		"origami-build-tools": "^10.1.8"
+		"origami-build-tools": "^10.8.6"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
 	"_origamiGlobalDependencies": {
 		"@financial-times/origami-bundle-size-cli": "^1.0.0",
 		"occ": "^0.16.2",
-		"origami-build-tools": "^10.8.6"
+		"origami-build-tools": "^10.8.7"
 	}
 }


### PR DESCRIPTION
the new version of obt builds the pa11y demo for all supported brands of the component instead of just the master brand.

Fixes https://github.com/Financial-Times/origami-ci-tools/issues/23