### PR TITLE
Create the prefix directory if it doesn't exist

### DIFF
--- a/lib/install-dependencies.js
+++ b/lib/install-dependencies.js
@@ -1,7 +1,7 @@
 import exec from './exec';
 import env from './env';
 import {resolve as resolvePath} from 'path';
-import {promises as fs} from 'fs';
+import {promises as fs, existsSync} from 'fs';
 
 export default async function installDependencies(names) {
 	if (!Array.isArray(names)) {
@@ -20,6 +20,13 @@ export default async function installDependencies(names) {
 		throw new Error(
 			"couldn't parse origami-ci package.json as JSON, ensure it's there and is valid json!"
 		);
+	}
+
+	if (!existsSync(env.npmInstallPrefix)) {
+		await fs.mkdir(env.npmInstallPrefix);
+		for (let sub of ['bin', 'lib']) {
+			await fs.mkdir(resolvePath(env.npmInstallPrefix, sub));
+		}
 	}
 
 	let specs = names.map(name => {


### PR DESCRIPTION
npm  7 no longer creates the root prefix.
it also expects `lib` and `bin` to already exist.

which is _fine_.