### PR TITLE
Create the prefix directory if it doesn't exist

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Get all tags from the origin
         if: github.event.pull_request.merged # Only run on merged pull-requests
-      - uses: Financial-Times/origami-version@v1
+      - uses: Financial-Times/origami-version@v1.1.3
         name: Create new version/tag
         if: github.event.pull_request.merged # Only run on merged pull-requests
         with:

--- a/.github/workflows/npm-audit-fix.yml
+++ b/.github/workflows/npm-audit-fix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ybiquitous/npm-audit-fix-action@v2.1.5
+      - uses: ybiquitous/npm-audit-fix-action@v2.1.6
         with:
           github_token: ${{ secrets.ORIGAMI_GITHUB_TOKEN }}
           # branch: "npm-audit-fix"

--- a/lib/install-dependencies.js
+++ b/lib/install-dependencies.js
@@ -1,7 +1,7 @@
 import exec from './exec';
 import env from './env';
 import {resolve as resolvePath} from 'path';
-import {promises as fs} from 'fs';
+import {promises as fs, existsSync} from 'fs';
 
 export default async function installDependencies(names) {
 	if (!Array.isArray(names)) {
@@ -20,6 +20,13 @@ export default async function installDependencies(names) {
 		throw new Error(
 			"couldn't parse origami-ci package.json as JSON, ensure it's there and is valid json!"
 		);
+	}
+
+	if (!existsSync(env.npmInstallPrefix)) {
+		await fs.mkdir(env.npmInstallPrefix);
+		for (let sub of ['bin', 'lib']) {
+			await fs.mkdir(resolvePath(env.npmInstallPrefix, sub));
+		}
 	}
 
 	let specs = names.map(name => {


### PR DESCRIPTION
npm  7 no longer creates the root prefix.
it also expects `lib` and `bin` to already exist.

which is _fine_.