### PR TITLE
Do not release prerelease components with the latest tag

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -37,7 +37,7 @@ export async function command() {
 		 version to ensure that it does not get tagged with `latest`.
 	*/
 	const prereleaseComponents = prerelease(env.version);
-	const newVersionIsNotPrerelease = prereleaseComponents.length === 0;
+	const newVersionIsNotPrerelease = prereleaseComponents === null;
 
 	let versions = [];
 	try {
@@ -58,8 +58,7 @@ export async function command() {
 	}
 
 	const stableVersions = versions.filter(version => {
-		const prereleaseComponents = prerelease(version);
-		return prereleaseComponents.length === 0;
+		return prerelease(version) === null;
 	});
 
 	const newVersionIsLargestVersion = stableVersions.every(version => {

--- a/commands/release.js
+++ b/commands/release.js
@@ -1,7 +1,7 @@
 import {promises as fs} from 'fs';
 import {homedir} from 'os';
 import {resolve as resolvePath} from 'path';
-import { gt, prerelease } from 'semver';
+import {gt, prerelease} from 'semver';
 
 import exec from '../lib/exec';
 import {execStdout} from '../lib/exec';

--- a/commands/release.js
+++ b/commands/release.js
@@ -1,7 +1,7 @@
 import {promises as fs} from 'fs';
 import {homedir} from 'os';
 import {resolve as resolvePath} from 'path';
-import {gt, coerce} from 'semver';
+import { gt, prerelease } from 'semver';
 
 import exec from '../lib/exec';
 import {execStdout} from '../lib/exec';
@@ -36,8 +36,8 @@ export async function command() {
 		 being published is either a prerelease or not the largest version then we tag the release with the
 		 version to ensure that it does not get tagged with `latest`.
 	*/
-	const newVersion = coerce(env.version);
-	const newVersionIsNotPrerelease = newVersion.prerelease.length === 0;
+	const prereleaseComponents = prerelease(env.version);
+	const newVersionIsNotPrerelease = prereleaseComponents.length === 0;
 
 	let versions = [];
 	try {
@@ -58,8 +58,8 @@ export async function command() {
 	}
 
 	const stableVersions = versions.filter(version => {
-		const v = coerce(version);
-		return v.prerelease.length === 0;
+		const prereleaseComponents = prerelease(version);
+		return prereleaseComponents.length === 0;
 	});
 
 	const newVersionIsLargestVersion = stableVersions.every(version => {


### PR DESCRIPTION
Previously this did not work as expected as `semver.coerce` does not
appear to handle prerelease versions. Relates to:
https://github.com/npm/node-semver/issues/357

Instead we can use `semver.prerelease` for our purposes.

We should improve test coverage here but I suspect this action
may disappear in the near future (either with a move to a mono
repo, or by extracting the bundle size notice and using a similar
approach to services for publishing).