### PR TITLE
Fix the release script

### DIFF
--- a/commands/release.js
+++ b/commands/release.js
@@ -64,7 +64,7 @@ export async function command() {
 	});
 
 	const newVersionIsLargestVersion = stableVersions.every(version => {
-		return gt(newVersion, version);
+		return gt(prereleaseComponents, version);
 	});
 
 	await exec('npm', 'version', env.version, '--no-git-tag-version', '--force');


### PR DESCRIPTION
The `newVersion` variable was renamed but all usecases were
not removed/updated.
https://github.com/Financial-Times/origami-ci-tools/pull/108

This should have been caught be testing or even linting. However
since origami-ci-tools will likely be deprecated soon let's not
add those now:
https://github.com/Financial-Times/origami-ci-tools/pull/95#issuecomment-780694654